### PR TITLE
feat: adiciona configuração baseURL para substituir URL hardcoded localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ interface WidgetConfig {
   welcomeMessage?: string;        // Mensagem de boas-vindas personalizada
   successMessage?: string;        // Mensagem de sucesso personalizada
   
+  // URL e Integração
+  baseURL?: string;               // URL base para o iframe do widget (ex: "https://api.exemplo.com/widget?flowId=123")
+  
   // Integração (futuro)
   apiEndpoint?: string;          // Endpoint da API
   apiKey?: string;               // Chave da API
@@ -163,6 +166,15 @@ Leadnator.initWidget({
   primaryColor: "#8B5CF6",
   autoOpen: true,
   showTimestamp: true
+});
+
+// Widget com URL personalizada
+Leadnator.initWidget({
+  id: "produção",
+  title: "Fale conosco",
+  position: "bottom-right",
+  baseURL: "https://api.meusite.com/widget?flowId=12345",
+  primaryColor: "#3B82F6"
 });
 ```
 

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "title": "LeadnatorX",
   "position": "bottom-right",
   "trigger": "button",
+  "baseURL": "http://localhost:3000/widget?flowId=68963b901d3edd1d9dfb13cd",
   "colors": {
     "primary": "#000000",
     "secondary": "#000000",

--- a/src/components/widget.tsx
+++ b/src/components/widget.tsx
@@ -13,7 +13,7 @@ export const Widget = ({ config }: WidgetProps) => {
 
   // Função helper para construir a URL do iframe
   const buildIframeUrl = () => {
-    const baseUrl = 'http://localhost:3000/widget?flowId=68963b901d3edd1d9dfb13cd';
+    const baseUrl = config.baseURL || 'http://localhost:3000/widget?flowId=68963b901d3edd1d9dfb13cd';
     const params = new URLSearchParams();
 
     // Cores do ícone

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -46,4 +46,5 @@ export interface WidgetConfig {
   trigger: 'button' | 'immediate' | 'delayed' | 'scroll' | 'exit-intent';
   colors: WidgetColors;
   windowLayout: WindowLayout;
+  baseURL?: string; // URL base para o iframe do widget
 }


### PR DESCRIPTION
## Descrição

Esta PR adiciona a funcionalidade de configurar a baseURL do widget através da configuração, substituindo a URL hardcoded localhost:3000.

## Mudanças

- ✅ Adiciona propriedade  na interface 
- ✅ Atualiza componente Widget para usar  em vez de URL hardcoded
- ✅ Atualiza arquivo de configuração com exemplo de baseURL
- ✅ Atualiza documentação README com nova propriedade
- ✅ Mantém compatibilidade com fallback para URL padrão

## Como usar



## Testes

- ✅ Build executado com sucesso
- ✅ Código compila sem erros
- ✅ Documentação atualizada